### PR TITLE
Add Find & Replace feature

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:streamkit_tts/models/enums/app_theme_mode.dart';
 import 'package:streamkit_tts/screens/home/home.dart';
 import 'package:streamkit_tts/screens/settings/beat_saber_settings.dart';
 import 'package:streamkit_tts/screens/settings/settings.dart';
+import 'package:streamkit_tts/screens/settings/replace_strings_settings.dart';
 import 'package:streamkit_tts/screens/settings/user_filter_settings.dart';
 import 'package:streamkit_tts/services/composers/app_composer_service.dart';
 import 'package:streamkit_tts/services/composers/composer_service.dart';
@@ -24,6 +25,7 @@ import 'package:streamkit_tts/services/middlewares/pachify_middleware.dart';
 import 'package:streamkit_tts/services/middlewares/read_username_middleware.dart';
 import 'package:streamkit_tts/services/middlewares/remove_emotes_middleware.dart';
 import 'package:streamkit_tts/services/middlewares/remove_urls_middleware.dart';
+import 'package:streamkit_tts/services/middlewares/replace_strings_middleware.dart';
 import 'package:streamkit_tts/services/middlewares/skip_empty_middleware.dart';
 import 'package:streamkit_tts/services/middlewares/skip_exclamation_middleware.dart';
 import 'package:streamkit_tts/services/middlewares/user_filter_middleware.dart';
@@ -77,6 +79,7 @@ void main() async {
       // Message clean-up middlewares
       RemoveEmotesMiddleware(config: config),
       RemoveUrlsMiddleware(config: config),
+      ReplaceStringsMiddleware(config: config),
 
       ForcedLanguageMiddleware(),
       PachifyMiddleware(
@@ -314,6 +317,8 @@ class MyApp extends StatelessWidget {
           '/settings': (context) => const SettingsScreen(),
           '/settings/user_filter': (context) =>
               const UserFilterSettingsScreen(),
+          '/settings/replace_strings': (context) =>
+              const ReplaceStringsSettingsScreen(),
         },
         debugShowCheckedModeBanner: false,
       ),

--- a/lib/models/chat_to_speech_config_model.dart
+++ b/lib/models/chat_to_speech_config_model.dart
@@ -4,6 +4,7 @@ import 'package:streamkit_tts/flavor_config.dart';
 import 'package:streamkit_tts/models/enums/languages_enum.dart';
 import 'package:streamkit_tts/models/enums/app_theme_mode.dart';
 import 'package:streamkit_tts/models/enums/tts_source.dart';
+import 'package:streamkit_tts/models/replace_string_rule.dart';
 
 class ChatToSpeechConfiguration {
   final Set<String> channels;
@@ -25,6 +26,7 @@ class ChatToSpeechConfiguration {
   final bool ignoreVtuberGroupName;
   final bool disableAKeongFilter;
   final AppThemeMode themeMode;
+  final List<ReplaceStringRule> replaceStringRules;
 
   ChatToSpeechConfiguration({
     required this.channels,
@@ -46,6 +48,7 @@ class ChatToSpeechConfiguration {
     required this.ignoreVtuberGroupName,
     required this.disableAKeongFilter,
     required this.themeMode,
+    required this.replaceStringRules,
   });
 
   ChatToSpeechConfiguration copyWith({
@@ -69,6 +72,7 @@ class ChatToSpeechConfiguration {
     bool? ignoreVtuberGroupName,
     bool? disableAKeongFilter,
     AppThemeMode? themeMode,
+    List<ReplaceStringRule>? replaceStringRules,
   }) {
     return ChatToSpeechConfiguration(
       channels: channels ?? this.channels,
@@ -92,6 +96,7 @@ class ChatToSpeechConfiguration {
           ignoreVtuberGroupName ?? this.ignoreVtuberGroupName,
       disableAKeongFilter: disableAKeongFilter ?? this.disableAKeongFilter,
       themeMode: themeMode ?? this.themeMode,
+      replaceStringRules: replaceStringRules ?? this.replaceStringRules,
     );
   }
 
@@ -117,6 +122,7 @@ class ChatToSpeechConfiguration {
     result.addAll({'ignoreVtuberGroupName': ignoreVtuberGroupName});
     result.addAll({'disableAKeongFilter': disableAKeongFilter});
     result.addAll({'themeMode': themeMode.name});
+    result.addAll({'replaceStringRules': replaceStringRules.map((r) => r.toMap()).toList()});
     return result;
   }
 
@@ -146,6 +152,10 @@ class ChatToSpeechConfiguration {
       ignoreVtuberGroupName: map['ignoreVtuberGroupName'] ?? true,
       disableAKeongFilter: map['disableAKeongFilter'] ?? false,
       themeMode: AppThemeMode.values.byName(map['themeMode'] ?? 'dark'),
+      replaceStringRules: (map['replaceStringRules'] as List<dynamic>?)
+              ?.map((e) => ReplaceStringRule.fromMap(e as Map<String, dynamic>))
+              .toList() ??
+          [],
     );
   }
 

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -3,6 +3,7 @@ import 'package:streamkit_tts/models/chat_to_speech_config_model.dart';
 import 'package:streamkit_tts/models/enums/languages_enum.dart';
 import 'package:streamkit_tts/models/enums/app_theme_mode.dart';
 import 'package:streamkit_tts/models/enums/tts_source.dart';
+import 'package:streamkit_tts/models/replace_string_rule.dart';
 
 class Config extends ChangeNotifier {
   ChatToSpeechConfiguration chatToSpeechConfiguration;
@@ -123,6 +124,14 @@ class Config extends ChangeNotifier {
     setChatToSpeechConfiguration(
       chatToSpeechConfiguration.copyWith(
         themeMode: themeMode,
+      ),
+    );
+  }
+
+  void setReplaceStringRules(List<ReplaceStringRule> rules) {
+    setChatToSpeechConfiguration(
+      chatToSpeechConfiguration.copyWith(
+        replaceStringRules: rules,
       ),
     );
   }

--- a/lib/models/replace_string_rule.dart
+++ b/lib/models/replace_string_rule.dart
@@ -1,23 +1,31 @@
+import 'package:uuid/uuid.dart';
+
+const _uuid = Uuid();
+
 class ReplaceStringRule {
+  final String id;
   final String from;
   final String to;
   final bool caseSensitive;
   final bool wholeWord;
 
-  const ReplaceStringRule({
+  ReplaceStringRule({
+    String? id,
     required this.from,
     required this.to,
     this.caseSensitive = false,
     this.wholeWord = false,
-  });
+  }) : id = id ?? _uuid.v4();
 
   ReplaceStringRule copyWith({
+    String? id,
     String? from,
     String? to,
     bool? caseSensitive,
     bool? wholeWord,
   }) {
     return ReplaceStringRule(
+      id: id ?? this.id,
       from: from ?? this.from,
       to: to ?? this.to,
       caseSensitive: caseSensitive ?? this.caseSensitive,
@@ -27,6 +35,7 @@ class ReplaceStringRule {
 
   Map<String, dynamic> toMap() {
     return {
+      'id': id,
       'from': from,
       'to': to,
       'caseSensitive': caseSensitive,
@@ -36,6 +45,7 @@ class ReplaceStringRule {
 
   factory ReplaceStringRule.fromMap(Map<String, dynamic> map) {
     return ReplaceStringRule(
+      id: map['id'] as String?,
       from: map['from'] as String,
       to: map['to'] as String,
       caseSensitive: map['caseSensitive'] as bool? ?? false,

--- a/lib/models/replace_string_rule.dart
+++ b/lib/models/replace_string_rule.dart
@@ -1,0 +1,45 @@
+class ReplaceStringRule {
+  final String from;
+  final String to;
+  final bool caseSensitive;
+  final bool wholeWord;
+
+  const ReplaceStringRule({
+    required this.from,
+    required this.to,
+    this.caseSensitive = false,
+    this.wholeWord = false,
+  });
+
+  ReplaceStringRule copyWith({
+    String? from,
+    String? to,
+    bool? caseSensitive,
+    bool? wholeWord,
+  }) {
+    return ReplaceStringRule(
+      from: from ?? this.from,
+      to: to ?? this.to,
+      caseSensitive: caseSensitive ?? this.caseSensitive,
+      wholeWord: wholeWord ?? this.wholeWord,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'from': from,
+      'to': to,
+      'caseSensitive': caseSensitive,
+      'wholeWord': wholeWord,
+    };
+  }
+
+  factory ReplaceStringRule.fromMap(Map<String, dynamic> map) {
+    return ReplaceStringRule(
+      from: map['from'] as String,
+      to: map['to'] as String,
+      caseSensitive: map['caseSensitive'] as bool? ?? false,
+      wholeWord: map['wholeWord'] as bool? ?? false,
+    );
+  }
+}

--- a/lib/screens/settings/config_group/filter_config_group.dart
+++ b/lib/screens/settings/config_group/filter_config_group.dart
@@ -28,6 +28,20 @@ class FilterConfig extends StatelessWidget {
           },
           left: const Icon(Icons.people_alt_outlined),
         ),
+        const Divider(
+          height: 1,
+          indent: 50,
+        ),
+        MenuSettings.submenu(
+          title: "Find & Replace",
+          onPressed: () {
+            Navigator.pushNamed(
+              context,
+              '/settings/replace_strings',
+            );
+          },
+          left: const Icon(Icons.find_replace),
+        ),
       ],
     );
   }

--- a/lib/screens/settings/replace_strings_settings.dart
+++ b/lib/screens/settings/replace_strings_settings.dart
@@ -167,7 +167,7 @@ void showRuleDialog(
                 onFieldSubmitted: (_) {
                   if (formKey.currentState!.validate()) {
                     _saveRule(context, fromController, toController,
-                        caseSensitive, wholeWord, index);
+                        caseSensitive, wholeWord, index, existingRule?.id);
                     Navigator.of(context).pop();
                   }
                 },
@@ -199,7 +199,7 @@ void showRuleDialog(
             onPressed: () {
               if (formKey.currentState!.validate()) {
                 _saveRule(context, fromController, toController, caseSensitive,
-                    wholeWord, index);
+                    wholeWord, index, existingRule?.id);
                 Navigator.of(context).pop();
               }
             },
@@ -218,11 +218,13 @@ void _saveRule(
   bool caseSensitive,
   bool wholeWord,
   int? index,
+  String? existingId,
 ) {
   final config = context.read<Config>();
   final rules = List<ReplaceStringRule>.from(
       config.chatToSpeechConfiguration.replaceStringRules);
   final newRule = ReplaceStringRule(
+    id: existingId,
     from: fromController.text,
     to: toController.text,
     caseSensitive: caseSensitive,

--- a/lib/screens/settings/replace_strings_settings.dart
+++ b/lib/screens/settings/replace_strings_settings.dart
@@ -36,12 +36,24 @@ class _ReplaceListConfigGroup extends StatelessWidget {
       ),
       right: const _AddRuleButton(),
       children: [
-        if (rules.isNotEmpty) ...[
-          for (int i = 0; i < rules.length; i++) ...[
-            _RuleListItem(rule: rules[i], index: i),
-            if (i < rules.length - 1) const Divider(height: 1, indent: 48),
-          ],
-        ],
+        if (rules.isNotEmpty)
+          ReorderableListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            buildDefaultDragHandles: false,
+            itemCount: rules.length,
+            onReorder: (oldIndex, newIndex) {
+              if (newIndex > oldIndex) newIndex--;
+              final updated = List<ReplaceStringRule>.from(rules);
+              updated.insert(newIndex, updated.removeAt(oldIndex));
+              context.read<Config>().setReplaceStringRules(updated);
+            },
+            itemBuilder: (context, i) => _RuleListItem(
+              key: ValueKey(i),
+              rule: rules[i],
+              index: i,
+            ),
+          ),
         if (rules.isEmpty)
           Padding(
             padding: const EdgeInsets.all(24.0),
@@ -230,7 +242,7 @@ class _RuleListItem extends StatelessWidget {
   final ReplaceStringRule rule;
   final int index;
 
-  const _RuleListItem({required this.rule, required this.index});
+  const _RuleListItem({super.key, required this.rule, required this.index});
 
   @override
   Widget build(BuildContext context) {
@@ -305,6 +317,24 @@ class _RuleListItem extends StatelessWidget {
               foregroundColor: Colors.red,
               minimumSize: const Size(32, 32),
               iconSize: 18,
+            ),
+          ),
+          const SizedBox(width: 4),
+          MouseRegion(
+            cursor: SystemMouseCursors.move,
+            child: ReorderableDragStartListener(
+              index: index,
+              child: Tooltip(
+                message: 'Drag to reorder',
+                child: Icon(
+                  Icons.drag_handle,
+                  size: 24,
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withValues(alpha: 0.3),
+                ),
+              ),
             ),
           ),
         ],

--- a/lib/screens/settings/replace_strings_settings.dart
+++ b/lib/screens/settings/replace_strings_settings.dart
@@ -49,7 +49,7 @@ class _ReplaceListConfigGroup extends StatelessWidget {
               context.read<Config>().setReplaceStringRules(updated);
             },
             itemBuilder: (context, i) => _RuleListItem(
-              key: ValueKey(i),
+              key: ValueKey(rules[i].id),
               rule: rules[i],
               index: i,
             ),
@@ -305,14 +305,12 @@ class _RuleListItem extends StatelessWidget {
             onPressed: () =>
                 showRuleDialog(context, existingRule: rule, index: index),
             icon: const Icon(Icons.edit),
-            tooltip: 'Edit rule',
             style: IconButton.styleFrom(
                 minimumSize: const Size(32, 32), iconSize: 18),
           ),
           IconButton(
             onPressed: () => _removeRule(context),
             icon: const Icon(Icons.delete),
-            tooltip: 'Delete rule',
             style: IconButton.styleFrom(
               foregroundColor: Colors.red,
               minimumSize: const Size(32, 32),
@@ -324,16 +322,13 @@ class _RuleListItem extends StatelessWidget {
             cursor: SystemMouseCursors.move,
             child: ReorderableDragStartListener(
               index: index,
-              child: Tooltip(
-                message: 'Drag to reorder',
-                child: Icon(
-                  Icons.drag_handle,
-                  size: 24,
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.3),
-                ),
+              child: Icon(
+                Icons.drag_handle,
+                size: 24,
+                color: Theme.of(context)
+                    .colorScheme
+                    .onSurface
+                    .withValues(alpha: 0.3),
               ),
             ),
           ),

--- a/lib/screens/settings/replace_strings_settings.dart
+++ b/lib/screens/settings/replace_strings_settings.dart
@@ -1,0 +1,346 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:streamkit_tts/models/config_model.dart';
+import 'package:streamkit_tts/models/replace_string_rule.dart';
+import 'package:streamkit_tts/widgets/config_container.dart';
+import 'package:streamkit_tts/widgets/inner_screen.dart';
+
+class ReplaceStringsSettingsScreen extends StatelessWidget {
+  const ReplaceStringsSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) => const InnerScreen(
+        title: "Find & Replace",
+        children: [
+          _ReplaceListConfigGroup(),
+        ],
+      );
+}
+
+class _ReplaceListConfigGroup extends StatelessWidget {
+  const _ReplaceListConfigGroup();
+
+  @override
+  Widget build(BuildContext context) {
+    final rules = context.select(
+      (Config config) => config.chatToSpeechConfiguration.replaceStringRules,
+    );
+
+    return ConfigContainer(
+      title: "Replace Rules",
+      subtitle: Text(
+        "Words or phrases in this list will be replaced before being spoken",
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+      ),
+      right: const _AddRuleButton(),
+      children: [
+        if (rules.isNotEmpty) ...[
+          for (int i = 0; i < rules.length; i++) ...[
+            _RuleListItem(rule: rules[i], index: i),
+            if (i < rules.length - 1) const Divider(height: 1, indent: 48),
+          ],
+        ],
+        if (rules.isEmpty)
+          Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Center(
+              child: Column(
+                children: [
+                  Icon(
+                    Icons.find_replace,
+                    size: 48,
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.3),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    "No replace rules yet",
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.6),
+                        ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    "Click the + button above to add a rule",
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.4),
+                        ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _AddRuleButton extends StatelessWidget {
+  const _AddRuleButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      onPressed: () => _showRuleDialog(context),
+      icon: const Icon(Icons.add, size: 18),
+      label: const Text("Add Rule"),
+      style: FilledButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      ),
+    );
+  }
+
+  void _showRuleDialog(BuildContext context) {
+    showRuleDialog(context, existingRule: null, index: null);
+  }
+}
+
+void showRuleDialog(
+  BuildContext context, {
+  required ReplaceStringRule? existingRule,
+  required int? index,
+}) {
+  final fromController = TextEditingController(text: existingRule?.from ?? '');
+  final toController = TextEditingController(text: existingRule?.to ?? '');
+  final formKey = GlobalKey<FormState>();
+  bool caseSensitive = existingRule?.caseSensitive ?? false;
+  bool wholeWord = existingRule?.wholeWord ?? false;
+
+  showDialog(
+    context: context,
+    builder: (context) => StatefulBuilder(
+      builder: (context, setState) => AlertDialog(
+        title: Text(existingRule != null ? 'Edit Rule' : 'Add Rule'),
+        content: Form(
+          key: formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextFormField(
+                controller: fromController,
+                decoration: const InputDecoration(
+                  labelText: 'Find',
+                  hintText: 'Text to find',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Find text cannot be empty';
+                  }
+                  return null;
+                },
+                autofocus: true,
+                textInputAction: TextInputAction.next,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: toController,
+                decoration: const InputDecoration(
+                  labelText: 'Replace with',
+                  hintText: 'Leave empty to remove the text',
+                  border: OutlineInputBorder(),
+                ),
+                textInputAction: TextInputAction.done,
+                onFieldSubmitted: (_) {
+                  if (formKey.currentState!.validate()) {
+                    _saveRule(context, fromController, toController,
+                        caseSensitive, wholeWord, index);
+                    Navigator.of(context).pop();
+                  }
+                },
+              ),
+              const SizedBox(height: 8),
+              SwitchListTile(
+                title: const Text('Case sensitive'),
+                value: caseSensitive,
+                onChanged: (value) => setState(() => caseSensitive = value),
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+              ),
+              SwitchListTile(
+                title: const Text('Whole word only'),
+                value: wholeWord,
+                onChanged: (value) => setState(() => wholeWord = value),
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              if (formKey.currentState!.validate()) {
+                _saveRule(context, fromController, toController, caseSensitive,
+                    wholeWord, index);
+                Navigator.of(context).pop();
+              }
+            },
+            child: Text(existingRule != null ? 'Save' : 'Add'),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+void _saveRule(
+  BuildContext context,
+  TextEditingController fromController,
+  TextEditingController toController,
+  bool caseSensitive,
+  bool wholeWord,
+  int? index,
+) {
+  final config = context.read<Config>();
+  final rules = List<ReplaceStringRule>.from(
+      config.chatToSpeechConfiguration.replaceStringRules);
+  final newRule = ReplaceStringRule(
+    from: fromController.text,
+    to: toController.text,
+    caseSensitive: caseSensitive,
+    wholeWord: wholeWord,
+  );
+
+  if (index != null) {
+    rules[index] = newRule;
+  } else {
+    rules.add(newRule);
+  }
+
+  config.setReplaceStringRules(rules);
+}
+
+class _RuleListItem extends StatelessWidget {
+  final ReplaceStringRule rule;
+  final int index;
+
+  const _RuleListItem({required this.rule, required this.index});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final toText = rule.to.isEmpty ? '(remove)' : '"${rule.to}"';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6.0, horizontal: 16.0),
+      child: Row(
+        children: [
+          const Icon(Icons.find_replace, size: 24),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      '"${rule.from}"',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 6),
+                      child: Icon(
+                        Icons.arrow_forward,
+                        size: 14,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    Text(
+                      toText,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: rule.to.isEmpty
+                            ? theme.colorScheme.onSurfaceVariant
+                            : null,
+                        fontStyle: rule.to.isEmpty ? FontStyle.italic : null,
+                      ),
+                    ),
+                  ],
+                ),
+                if (rule.caseSensitive || rule.wholeWord) ...[
+                  const SizedBox(height: 2),
+                  Row(
+                    children: [
+                      if (rule.caseSensitive)
+                        const _Badge(label: 'Case sensitive'),
+                      if (rule.caseSensitive && rule.wholeWord)
+                        const SizedBox(width: 4),
+                      if (rule.wholeWord) const _Badge(label: 'Whole word'),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                ],
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: () =>
+                showRuleDialog(context, existingRule: rule, index: index),
+            icon: const Icon(Icons.edit),
+            tooltip: 'Edit rule',
+            style: IconButton.styleFrom(
+                minimumSize: const Size(32, 32), iconSize: 18),
+          ),
+          IconButton(
+            onPressed: () => _removeRule(context),
+            icon: const Icon(Icons.delete),
+            tooltip: 'Delete rule',
+            style: IconButton.styleFrom(
+              foregroundColor: Colors.red,
+              minimumSize: const Size(32, 32),
+              iconSize: 18,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _removeRule(BuildContext context) {
+    final config = context.read<Config>();
+    final rules = List<ReplaceStringRule>.from(
+        config.chatToSpeechConfiguration.replaceStringRules);
+    rules.removeAt(index);
+    config.setReplaceStringRules(rules);
+  }
+}
+
+class _Badge extends StatelessWidget {
+  final String label;
+
+  const _Badge({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/middlewares/name_fix_middleware.dart
+++ b/lib/services/middlewares/name_fix_middleware.dart
@@ -51,10 +51,10 @@ class NameFixMiddleware implements Middleware {
         .fold(
           message.suggestedSpeechMessage,
           (message, name) {
-            final replacedMessaged = message.replaceWords(
+            final replacedMessaged = message.replaceStrings(
               [name.$1],
               replacement: name.$2 ?? '',
-              replaceEndOfSentenceWord: true,
+              wholeWord: true,
               caseInsensitive: true,
               isUsername: true,
             );

--- a/lib/services/middlewares/remove_emotes_middleware.dart
+++ b/lib/services/middlewares/remove_emotes_middleware.dart
@@ -34,7 +34,7 @@ class RemoveEmotesMiddleware implements Middleware {
           '',
         );
       },
-    ).replaceWords(emoteList);
+    ).replaceStrings(emoteList, wholeWord: true);
 
     return message.copyWith(suggestedSpeechMessage: emotelessMessage);
   }

--- a/lib/services/middlewares/replace_strings_middleware.dart
+++ b/lib/services/middlewares/replace_strings_middleware.dart
@@ -1,0 +1,32 @@
+import 'package:streamkit_tts/models/config_model.dart';
+import 'package:streamkit_tts/models/messages/chat_message.dart';
+import 'package:streamkit_tts/models/messages/message.dart';
+import 'package:streamkit_tts/services/middlewares/middleware.dart';
+import 'package:streamkit_tts/utils/clean_message_util.dart';
+
+class ReplaceStringsMiddleware implements Middleware {
+  final Config _config;
+
+  ReplaceStringsMiddleware({required Config config}) : _config = config;
+
+  @override
+  Future<Message?> process(Message message) async {
+    if (message is! ChatMessage) return message;
+
+    final rules = _config.chatToSpeechConfiguration.replaceStringRules;
+    if (rules.isEmpty) return message;
+
+    String result = message.suggestedSpeechMessage;
+
+    for (final rule in rules) {
+      result = result.replaceStrings(
+        [rule.from],
+        replacement: rule.to,
+        wholeWord: rule.wholeWord,
+        caseInsensitive: !rule.caseSensitive,
+      );
+    }
+
+    return message.copyWith(suggestedSpeechMessage: result);
+  }
+}

--- a/lib/services/middlewares/word_fix_middleware.dart
+++ b/lib/services/middlewares/word_fix_middleware.dart
@@ -51,10 +51,10 @@ class WordFixMiddleware implements Middleware {
         .fold(
           message.suggestedSpeechMessage,
           (message, name) {
-            final replacedMessaged = message.replaceWords(
+            final replacedMessaged = message.replaceStrings(
               [name.$1],
               replacement: name.$2 ?? '',
-              replaceEndOfSentenceWord: true,
+              wholeWord: true,
               caseInsensitive: true,
             );
 

--- a/lib/utils/clean_message_util.dart
+++ b/lib/utils/clean_message_util.dart
@@ -1,60 +1,35 @@
 extension CleanMessage on String {
-  String replaceWords(
+  String replaceStrings(
     List<String> replaceList, {
     String replacement = "",
-    bool replaceEndOfSentenceWord = false,
+    bool wholeWord = false,
     bool caseInsensitive = false,
     bool isUsername = false,
   }) {
     String result = this;
 
-    // Define punctuation characters to include
-    String punctuation = '.,!?:;';
-
     for (String toReplace in replaceList) {
-      // Build the leading pattern
-      String leadingPattern;
-      if (isUsername) {
-        leadingPattern = r'(^|\s|@)';
+      if (wholeWord) {
+        final leadingPattern = isUsername ? r'(^|\s|@)' : r'(^|\s)';
+        final patternString =
+            leadingPattern + RegExp.escape(toReplace) + r'(\s|[.,!?:;]|$)';
+
+        final pattern = RegExp(patternString, caseSensitive: !caseInsensitive);
+
+        result = result.replaceAllMapped(pattern, (match) {
+          final before = match.group(1) ?? '';
+          final after = match.group(2) ?? '';
+          return before + replacement + after;
+        });
       } else {
-        leadingPattern = r'(^|\s)';
+        final pattern = RegExp(
+          RegExp.escape(toReplace),
+          caseSensitive: !caseInsensitive,
+        );
+        result = result.replaceAll(pattern, replacement);
       }
-
-      // Build the regular expression pattern using string interpolation
-      String patternString;
-      if (replaceEndOfSentenceWord) {
-        patternString = leadingPattern +
-            RegExp.escape(toReplace) +
-            r'(\s|[' +
-            RegExp.escape(punctuation) +
-            r']|$)';
-      } else {
-        patternString = r'(^|\s)' + RegExp.escape(toReplace) + r'(\s|$)';
-      }
-
-      // Build the regex with the appropriate options
-      RegExp pattern = RegExp(
-        patternString,
-        caseSensitive: !caseInsensitive,
-      );
-
-      result = result.replaceAllMapped(pattern, (match) {
-        // Capture leading and trailing characters
-        String before = match.group(1) ?? '';
-        String after = match.group(2) ?? '';
-
-        // If after is punctuation and we are removing the word, remove the punctuation
-        if (replaceEndOfSentenceWord &&
-            replacement.isEmpty &&
-            punctuation.contains(after.trim())) {
-          after = '';
-        }
-
-        return before + replacement + after;
-      });
     }
 
-    // Trim any extra spaces from the result
     return result.trim();
   }
 


### PR DESCRIPTION
## Summary
- Adds a user-configurable Find & Replace feature that swaps words or phrases in chat messages before they are read aloud
- Each rule supports a custom replacement string (or empty to remove), with options for case sensitivity and whole-word matching
- Rules are applied in order and can be drag-reordered in the settings UI

## How it works
- New `ReplaceStringRule` model stored in config JSON under `replaceStringRules`
- New `ReplaceStringsMiddleware` applies rules using the existing `replaceStrings` utility in `clean_message_util.dart`
- Settings screen accessible via Settings → Filters → Find & Replace


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the chat message cleanup pipeline and string replacement semantics, which can subtly affect what gets spoken and how existing configs are serialized/deserialized.
> 
> **Overview**
> Adds a user-configurable **Find & Replace** feature that rewrites chat text *before* it is spoken, with per-rule options for case sensitivity and whole-word matching and support for drag-reordering.
> 
> This persists rules in config JSON via a new `ReplaceStringRule` model and `replaceStringRules` field, exposes editing UI under Settings → Filters, and applies the rules via a new `ReplaceStringsMiddleware` inserted into the main middleware chain.
> 
> Also refactors the string replacement utility from `replaceWords` to `replaceStrings` (and updates callers) to support both whole-word regex replacement and general substring replacement behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a54eb2033ee776d3db86d92dbbf2bb1561d2dc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->