### PR TITLE
Add Word Filter feature

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,8 @@ import 'package:streamkit_tts/screens/settings/beat_saber_settings.dart';
 import 'package:streamkit_tts/screens/settings/settings.dart';
 import 'package:streamkit_tts/screens/settings/replace_strings_settings.dart';
 import 'package:streamkit_tts/screens/settings/user_filter_settings.dart';
+import 'package:streamkit_tts/screens/settings/word_filter_settings.dart';
+import 'package:streamkit_tts/services/middlewares/word_filter_middleware.dart';
 import 'package:streamkit_tts/services/composers/app_composer_service.dart';
 import 'package:streamkit_tts/services/composers/composer_service.dart';
 import 'package:streamkit_tts/services/language_detection_service.dart';
@@ -73,6 +75,7 @@ void main() async {
         versionCheckService: versionCheckService,
       ),
       UserFilterMiddleware(config: config),
+      WordFilterMiddleware(config: config),
       BsrMiddleware(config: config),
       SkipExclamationMiddleware(config: config),
 
@@ -319,6 +322,8 @@ class MyApp extends StatelessWidget {
               const UserFilterSettingsScreen(),
           '/settings/replace_strings': (context) =>
               const ReplaceStringsSettingsScreen(),
+          '/settings/word_filter': (context) =>
+              const WordFilterSettingsScreen(),
         },
         debugShowCheckedModeBanner: false,
       ),

--- a/lib/models/chat_to_speech_config_model.dart
+++ b/lib/models/chat_to_speech_config_model.dart
@@ -5,6 +5,7 @@ import 'package:streamkit_tts/models/enums/languages_enum.dart';
 import 'package:streamkit_tts/models/enums/app_theme_mode.dart';
 import 'package:streamkit_tts/models/enums/tts_source.dart';
 import 'package:streamkit_tts/models/replace_string_rule.dart';
+import 'package:streamkit_tts/models/word_filter_rule.dart';
 
 class ChatToSpeechConfiguration {
   final Set<String> channels;
@@ -27,6 +28,8 @@ class ChatToSpeechConfiguration {
   final bool disableAKeongFilter;
   final AppThemeMode themeMode;
   final List<ReplaceStringRule> replaceStringRules;
+  final List<WordFilterRule> wordFilterRules;
+  final bool isWordlistWhitelist;
 
   ChatToSpeechConfiguration({
     required this.channels,
@@ -49,6 +52,8 @@ class ChatToSpeechConfiguration {
     required this.disableAKeongFilter,
     required this.themeMode,
     required this.replaceStringRules,
+    required this.wordFilterRules,
+    required this.isWordlistWhitelist,
   });
 
   ChatToSpeechConfiguration copyWith({
@@ -73,6 +78,8 @@ class ChatToSpeechConfiguration {
     bool? disableAKeongFilter,
     AppThemeMode? themeMode,
     List<ReplaceStringRule>? replaceStringRules,
+    List<WordFilterRule>? wordFilterRules,
+    bool? isWordlistWhitelist,
   }) {
     return ChatToSpeechConfiguration(
       channels: channels ?? this.channels,
@@ -97,6 +104,8 @@ class ChatToSpeechConfiguration {
       disableAKeongFilter: disableAKeongFilter ?? this.disableAKeongFilter,
       themeMode: themeMode ?? this.themeMode,
       replaceStringRules: replaceStringRules ?? this.replaceStringRules,
+      wordFilterRules: wordFilterRules ?? this.wordFilterRules,
+      isWordlistWhitelist: isWordlistWhitelist ?? this.isWordlistWhitelist,
     );
   }
 
@@ -123,6 +132,8 @@ class ChatToSpeechConfiguration {
     result.addAll({'disableAKeongFilter': disableAKeongFilter});
     result.addAll({'themeMode': themeMode.name});
     result.addAll({'replaceStringRules': replaceStringRules.map((r) => r.toMap()).toList()});
+    result.addAll({'wordFilterRules': wordFilterRules.map((r) => r.toMap()).toList()});
+    result.addAll({'isWordlistWhitelist': isWordlistWhitelist});
     return result;
   }
 
@@ -156,6 +167,11 @@ class ChatToSpeechConfiguration {
               ?.map((e) => ReplaceStringRule.fromMap(e as Map<String, dynamic>))
               .toList() ??
           [],
+      wordFilterRules: (map['wordFilterRules'] as List<dynamic>?)
+              ?.map((e) => WordFilterRule.fromMap(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      isWordlistWhitelist: map['isWordlistWhitelist'] as bool? ?? false,
     );
   }
 

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -4,6 +4,7 @@ import 'package:streamkit_tts/models/enums/languages_enum.dart';
 import 'package:streamkit_tts/models/enums/app_theme_mode.dart';
 import 'package:streamkit_tts/models/enums/tts_source.dart';
 import 'package:streamkit_tts/models/replace_string_rule.dart';
+import 'package:streamkit_tts/models/word_filter_rule.dart';
 
 class Config extends ChangeNotifier {
   ChatToSpeechConfiguration chatToSpeechConfiguration;
@@ -124,6 +125,18 @@ class Config extends ChangeNotifier {
     setChatToSpeechConfiguration(
       chatToSpeechConfiguration.copyWith(
         themeMode: themeMode,
+      ),
+    );
+  }
+
+  void setWordFilter({
+    required List<WordFilterRule> rules,
+    required bool isWhitelistingFilter,
+  }) {
+    setChatToSpeechConfiguration(
+      chatToSpeechConfiguration.copyWith(
+        wordFilterRules: rules,
+        isWordlistWhitelist: isWhitelistingFilter,
       ),
     );
   }

--- a/lib/models/word_filter_rule.dart
+++ b/lib/models/word_filter_rule.dart
@@ -1,0 +1,49 @@
+import 'package:uuid/uuid.dart';
+
+const _uuid = Uuid();
+
+class WordFilterRule {
+  final String id;
+  final String word;
+  final bool caseSensitive;
+  final bool wholeWord;
+
+  WordFilterRule({
+    String? id,
+    required this.word,
+    this.caseSensitive = false,
+    this.wholeWord = false,
+  }) : id = id ?? _uuid.v4();
+
+  WordFilterRule copyWith({
+    String? id,
+    String? word,
+    bool? caseSensitive,
+    bool? wholeWord,
+  }) {
+    return WordFilterRule(
+      id: id ?? this.id,
+      word: word ?? this.word,
+      caseSensitive: caseSensitive ?? this.caseSensitive,
+      wholeWord: wholeWord ?? this.wholeWord,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'word': word,
+      'caseSensitive': caseSensitive,
+      'wholeWord': wholeWord,
+    };
+  }
+
+  factory WordFilterRule.fromMap(Map<String, dynamic> map) {
+    return WordFilterRule(
+      id: map['id'] as String?,
+      word: map['word'] as String,
+      caseSensitive: map['caseSensitive'] as bool? ?? false,
+      wholeWord: map['wholeWord'] as bool? ?? false,
+    );
+  }
+}

--- a/lib/screens/settings/config_group/filter_config_group.dart
+++ b/lib/screens/settings/config_group/filter_config_group.dart
@@ -33,6 +33,20 @@ class FilterConfig extends StatelessWidget {
           indent: 50,
         ),
         MenuSettings.submenu(
+          title: "Word Filter",
+          onPressed: () {
+            Navigator.pushNamed(
+              context,
+              '/settings/word_filter',
+            );
+          },
+          left: const Icon(Icons.filter_list),
+        ),
+        const Divider(
+          height: 1,
+          indent: 50,
+        ),
+        MenuSettings.submenu(
           title: "Find & Replace",
           onPressed: () {
             Navigator.pushNamed(

--- a/lib/screens/settings/config_group/filter_config_group.dart
+++ b/lib/screens/settings/config_group/filter_config_group.dart
@@ -42,20 +42,6 @@ class FilterConfig extends StatelessWidget {
           },
           left: const Icon(Icons.short_text_outlined),
         ),
-        const Divider(
-          height: 1,
-          indent: 50,
-        ),
-        MenuSettings.submenu(
-          title: "Find & Replace",
-          onPressed: () {
-            Navigator.pushNamed(
-              context,
-              '/settings/replace_strings',
-            );
-          },
-          left: const Icon(Icons.find_replace),
-        ),
       ],
     );
   }

--- a/lib/screens/settings/config_group/filter_config_group.dart
+++ b/lib/screens/settings/config_group/filter_config_group.dart
@@ -40,7 +40,7 @@ class FilterConfig extends StatelessWidget {
               '/settings/word_filter',
             );
           },
-          left: const Icon(Icons.filter_list),
+          left: const Icon(Icons.short_text_outlined),
         ),
         const Divider(
           height: 1,

--- a/lib/screens/settings/config_group/message_cleanup_config_group.dart
+++ b/lib/screens/settings/config_group/message_cleanup_config_group.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:streamkit_tts/flavor_config.dart';
 import 'package:streamkit_tts/models/config_model.dart';
 import 'package:streamkit_tts/widgets/config_container.dart';
+import 'package:streamkit_tts/widgets/menu_settings.dart';
 import 'package:streamkit_tts/widgets/switch_settings.dart';
 
 class MessageCleanUpConfig extends StatelessWidget {
@@ -11,13 +12,15 @@ class MessageCleanUpConfig extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ConfigContainer(
+    return const ConfigContainer(
       title: "Message Clean-up",
       children: [
-        const _RemoveEmotesConfig(),
-        const Divider(height: 1, indent: 50),
-        if (FlavorConfig.isTwitch) const _RemoveBttvEmotesConfig(),
-        const _RemoveUrlsConfig(),
+        _RemoveEmotesConfig(),
+        Divider(height: 1, indent: 50),
+        if (FlavorConfig.isTwitch) _RemoveBttvEmotesConfig(),
+        _RemoveUrlsConfig(),
+        Divider(height: 1, indent: 50),
+        _FindAndReplaceConfig(),
       ],
     );
   }
@@ -110,6 +113,24 @@ class _RemoveUrlsConfig extends StatelessWidget {
         context.read<Config>().setTtsConfig(ignoreUrls: value);
       },
       left: const Icon(Icons.link_rounded),
+    );
+  }
+}
+
+class _FindAndReplaceConfig extends StatelessWidget {
+  const _FindAndReplaceConfig();
+
+  @override
+  Widget build(BuildContext context) {
+    return MenuSettings.submenu(
+      title: "Find & Replace",
+      onPressed: () {
+        Navigator.pushNamed(
+          context,
+          '/settings/replace_strings',
+        );
+      },
+      left: const Icon(Icons.find_replace),
     );
   }
 }

--- a/lib/screens/settings/word_filter_settings.dart
+++ b/lib/screens/settings/word_filter_settings.dart
@@ -1,0 +1,381 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:streamkit_tts/models/config_model.dart';
+import 'package:streamkit_tts/models/word_filter_rule.dart';
+import 'package:streamkit_tts/widgets/config_container.dart';
+import 'package:streamkit_tts/widgets/inner_screen.dart';
+import 'package:streamkit_tts/widgets/radio_settings.dart';
+import 'package:streamkit_tts/utils/theme_extensions.dart';
+
+class WordFilterSettingsScreen extends StatelessWidget {
+  const WordFilterSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) => const InnerScreen(
+        title: "Word Filter",
+        children: [
+          _FilterModeConfigGroup(),
+          _WordListConfigGroup(),
+        ],
+      );
+}
+
+class _FilterModeConfigGroup extends StatelessWidget {
+  const _FilterModeConfigGroup();
+
+  @override
+  Widget build(BuildContext context) {
+    final isWhitelist = context.select(
+      (Config config) => config.chatToSpeechConfiguration.isWordlistWhitelist,
+    );
+
+    return ConfigContainer(
+      title: "How should the word filter work?",
+      children: [
+        RadioSettings<bool>(
+          options: [
+            RadioOption(
+              value: false,
+              title: "Block Mode",
+              subtitle: "Skip messages containing words in the list",
+              icon: Icons.block,
+              selectedColor: context.customColors.failure,
+            ),
+            RadioOption(
+              value: true,
+              title: "Allowlist Mode",
+              subtitle: "Only read messages containing words in the list",
+              icon: Icons.check_circle_outline,
+              selectedColor: context.customColors.success,
+            ),
+          ],
+          selectedValue: isWhitelist,
+          onChanged: (value) {
+            final config = context.read<Config>();
+            config.setWordFilter(
+              rules: config.chatToSpeechConfiguration.wordFilterRules,
+              isWhitelistingFilter: value,
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _WordListConfigGroup extends StatelessWidget {
+  const _WordListConfigGroup();
+
+  @override
+  Widget build(BuildContext context) {
+    final rules = context.select(
+      (Config config) => config.chatToSpeechConfiguration.wordFilterRules,
+    );
+
+    final isWhitelist = context.select(
+      (Config config) => config.chatToSpeechConfiguration.isWordlistWhitelist,
+    );
+
+    final theme = Theme.of(context);
+
+    return ConfigContainer(
+      title: "Word List",
+      subtitle: Row(
+        children: [
+          Text(
+            isWhitelist
+                ? "Only messages containing these words will be read"
+                : "Messages containing these words will not be read",
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: isWhitelist
+                  ? context.customColors.success
+                  : context.customColors.failure,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ],
+      ),
+      right: const _AddWordButton(),
+      children: [
+        if (rules.isNotEmpty) ...[
+          for (int i = 0; i < rules.length; i++) ...[
+            _WordListItem(rule: rules[i], index: i),
+            if (i < rules.length - 1) const Divider(height: 1, indent: 48),
+          ],
+        ],
+        if (rules.isEmpty)
+          Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Center(
+              child: Column(
+                children: [
+                  Icon(
+                    Icons.filter_list,
+                    size: 48,
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.3),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    isWhitelist ? "No words allowed yet" : "No words blocked yet",
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.6),
+                        ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    "Click the + button above to add words",
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.4),
+                        ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _AddWordButton extends StatelessWidget {
+  const _AddWordButton();
+
+  @override
+  Widget build(BuildContext context) {
+    final isWhitelist = context.select(
+      (Config config) => config.chatToSpeechConfiguration.isWordlistWhitelist,
+    );
+
+    return FilledButton.icon(
+      onPressed: () => _showWordDialog(context, existingRule: null, index: null),
+      icon: const Icon(Icons.add, size: 18),
+      label: Text(isWhitelist ? "Allow Word" : "Block Word"),
+      style: FilledButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        backgroundColor: isWhitelist
+            ? context.customColors.success
+            : context.customColors.failure,
+        foregroundColor: Theme.of(context).colorScheme.onSurface,
+      ),
+    );
+  }
+}
+
+void _showWordDialog(
+  BuildContext context, {
+  required WordFilterRule? existingRule,
+  required int? index,
+}) {
+  final wordController = TextEditingController(text: existingRule?.word ?? '');
+  final formKey = GlobalKey<FormState>();
+  bool caseSensitive = existingRule?.caseSensitive ?? false;
+  bool wholeWord = existingRule?.wholeWord ?? false;
+
+  showDialog(
+    context: context,
+    builder: (context) => StatefulBuilder(
+      builder: (context, setState) => AlertDialog(
+        title: Text(existingRule != null ? 'Edit Word' : 'Add Word'),
+        content: Form(
+          key: formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextFormField(
+                controller: wordController,
+                decoration: const InputDecoration(
+                  labelText: 'Word or phrase',
+                  hintText: 'Text to filter',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Word cannot be empty';
+                  }
+                  return null;
+                },
+                autofocus: true,
+                textInputAction: TextInputAction.done,
+                onFieldSubmitted: (_) {
+                  if (formKey.currentState!.validate()) {
+                    _saveRule(context, wordController, caseSensitive, wholeWord,
+                        index, existingRule?.id);
+                    Navigator.of(context).pop();
+                  }
+                },
+              ),
+              const SizedBox(height: 8),
+              SwitchListTile(
+                title: const Text('Case sensitive'),
+                value: caseSensitive,
+                onChanged: (value) => setState(() => caseSensitive = value),
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+              ),
+              SwitchListTile(
+                title: const Text('Whole word only'),
+                value: wholeWord,
+                onChanged: (value) => setState(() => wholeWord = value),
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              if (formKey.currentState!.validate()) {
+                _saveRule(context, wordController, caseSensitive, wholeWord,
+                    index, existingRule?.id);
+                Navigator.of(context).pop();
+              }
+            },
+            child: Text(existingRule != null ? 'Save' : 'Add'),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+void _saveRule(
+  BuildContext context,
+  TextEditingController wordController,
+  bool caseSensitive,
+  bool wholeWord,
+  int? index,
+  String? existingId,
+) {
+  final config = context.read<Config>();
+  final rules = List<WordFilterRule>.from(
+      config.chatToSpeechConfiguration.wordFilterRules);
+  final newRule = WordFilterRule(
+    id: existingId,
+    word: wordController.text,
+    caseSensitive: caseSensitive,
+    wholeWord: wholeWord,
+  );
+
+  if (index != null) {
+    rules[index] = newRule;
+  } else {
+    rules.add(newRule);
+  }
+
+  config.setWordFilter(
+    rules: rules,
+    isWhitelistingFilter:
+        config.chatToSpeechConfiguration.isWordlistWhitelist,
+  );
+}
+
+class _WordListItem extends StatelessWidget {
+  final WordFilterRule rule;
+  final int index;
+
+  const _WordListItem({required this.rule, required this.index});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6.0, horizontal: 16.0),
+      child: Row(
+        children: [
+          const Icon(Icons.filter_list, size: 24),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(rule.word, style: Theme.of(context).textTheme.bodyMedium),
+                if (rule.caseSensitive || rule.wholeWord) ...[
+                  const SizedBox(height: 2),
+                  Row(
+                    children: [
+                      if (rule.caseSensitive)
+                        const _Badge(label: 'Case sensitive'),
+                      if (rule.caseSensitive && rule.wholeWord)
+                        const SizedBox(width: 4),
+                      if (rule.wholeWord) const _Badge(label: 'Whole word'),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                ],
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: () =>
+                _showWordDialog(context, existingRule: rule, index: index),
+            icon: const Icon(Icons.edit),
+            tooltip: 'Edit word',
+            style: IconButton.styleFrom(
+                minimumSize: const Size(32, 32), iconSize: 18),
+          ),
+          IconButton(
+            onPressed: () => _removeRule(context),
+            icon: const Icon(Icons.delete),
+            tooltip: 'Delete word',
+            style: IconButton.styleFrom(
+              foregroundColor: Colors.red,
+              minimumSize: const Size(32, 32),
+              iconSize: 18,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _removeRule(BuildContext context) {
+    final config = context.read<Config>();
+    final rules = List<WordFilterRule>.from(
+        config.chatToSpeechConfiguration.wordFilterRules);
+    rules.removeAt(index);
+    config.setWordFilter(
+      rules: rules,
+      isWhitelistingFilter:
+          config.chatToSpeechConfiguration.isWordlistWhitelist,
+    );
+  }
+}
+
+class _Badge extends StatelessWidget {
+  final String label;
+
+  const _Badge({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/word_filter_settings.dart
+++ b/lib/screens/settings/word_filter_settings.dart
@@ -110,7 +110,7 @@ class _WordListConfigGroup extends StatelessWidget {
               child: Column(
                 children: [
                   Icon(
-                    Icons.filter_list,
+                    Icons.short_text,
                     size: 48,
                     color: Theme.of(context)
                         .colorScheme
@@ -119,7 +119,9 @@ class _WordListConfigGroup extends StatelessWidget {
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    isWhitelist ? "No words allowed yet" : "No words blocked yet",
+                    isWhitelist
+                        ? "No words allowed yet"
+                        : "No words blocked yet",
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                           color: Theme.of(context)
                               .colorScheme
@@ -156,7 +158,8 @@ class _AddWordButton extends StatelessWidget {
     );
 
     return FilledButton.icon(
-      onPressed: () => _showWordDialog(context, existingRule: null, index: null),
+      onPressed: () =>
+          _showWordDialog(context, existingRule: null, index: null),
       icon: const Icon(Icons.add, size: 18),
       label: Text(isWhitelist ? "Allow Word" : "Block Word"),
       style: FilledButton.styleFrom(
@@ -279,8 +282,7 @@ void _saveRule(
 
   config.setWordFilter(
     rules: rules,
-    isWhitelistingFilter:
-        config.chatToSpeechConfiguration.isWordlistWhitelist,
+    isWhitelistingFilter: config.chatToSpeechConfiguration.isWordlistWhitelist,
   );
 }
 

--- a/lib/screens/settings/word_filter_settings.dart
+++ b/lib/screens/settings/word_filter_settings.dart
@@ -345,7 +345,7 @@ class _WordListItem extends StatelessWidget {
     final config = context.read<Config>();
     final rules = List<WordFilterRule>.from(
         config.chatToSpeechConfiguration.wordFilterRules);
-    rules.removeAt(index);
+    rules.removeWhere((r) => r.id == rule.id);
     config.setWordFilter(
       rules: rules,
       isWhitelistingFilter:

--- a/lib/screens/settings/word_filter_settings.dart
+++ b/lib/screens/settings/word_filter_settings.dart
@@ -80,20 +80,16 @@ class _WordListConfigGroup extends StatelessWidget {
 
     return ConfigContainer(
       title: "Word List",
-      subtitle: Row(
-        children: [
-          Text(
-            isWhitelist
-                ? "Only messages containing these words will be read"
-                : "Messages containing these words will not be read",
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: isWhitelist
-                  ? context.customColors.success
-                  : context.customColors.failure,
-              fontWeight: FontWeight.w800,
-            ),
-          ),
-        ],
+      subtitle: Text(
+        isWhitelist
+            ? "Only messages containing these words will be read"
+            : "Messages containing these words will not be read",
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: isWhitelist
+              ? context.customColors.success
+              : context.customColors.failure,
+          fontWeight: FontWeight.w800,
+        ),
       ),
       right: const _AddWordButton(),
       children: [

--- a/lib/services/middlewares/word_filter_middleware.dart
+++ b/lib/services/middlewares/word_filter_middleware.dart
@@ -1,0 +1,35 @@
+import 'package:streamkit_tts/models/config_model.dart';
+import 'package:streamkit_tts/models/messages/chat_message.dart';
+import 'package:streamkit_tts/models/messages/message.dart';
+import 'package:streamkit_tts/services/middlewares/middleware.dart';
+import 'package:streamkit_tts/utils/clean_message_util.dart';
+
+class WordFilterMiddleware implements Middleware {
+  final Config _config;
+
+  WordFilterMiddleware({required Config config}) : _config = config;
+
+  @override
+  Future<Message?> process(Message message) async {
+    if (message is! ChatMessage) return message;
+
+    final rules = _config.chatToSpeechConfiguration.wordFilterRules;
+    if (rules.isEmpty) return message;
+
+    final text = message.suggestedSpeechMessage;
+
+    final matchesAny = rules.any((rule) => text.containsString(
+          rule.word,
+          wholeWord: rule.wholeWord,
+          caseInsensitive: !rule.caseSensitive,
+        ));
+
+    final isWhitelist = _config.chatToSpeechConfiguration.isWordlistWhitelist;
+
+    if (isWhitelist) {
+      return matchesAny ? message : null;
+    } else {
+      return matchesAny ? null : message;
+    }
+  }
+}

--- a/lib/utils/clean_message_util.dart
+++ b/lib/utils/clean_message_util.dart
@@ -9,28 +9,37 @@ extension CleanMessage on String {
     String result = this;
 
     for (String toReplace in replaceList) {
+      final pattern = _buildStringMatchPattern(
+        toReplace,
+        wholeWord: wholeWord,
+        caseInsensitive: caseInsensitive,
+        isUsername: isUsername,
+      );
+
       if (wholeWord) {
-        final leadingPattern = isUsername ? r'(^|\s|@)' : r'(^|\s)';
-        final patternString =
-            leadingPattern + RegExp.escape(toReplace) + r'(\s|[.,!?:;]|$)';
-
-        final pattern = RegExp(patternString, caseSensitive: !caseInsensitive);
-
         result = result.replaceAllMapped(pattern, (match) {
           final before = match.group(1) ?? '';
           final after = match.group(2) ?? '';
           return before + replacement + after;
         });
       } else {
-        final pattern = RegExp(
-          RegExp.escape(toReplace),
-          caseSensitive: !caseInsensitive,
-        );
         result = result.replaceAll(pattern, replacement);
       }
     }
 
     return result.trim();
+  }
+
+  bool containsString(
+    String needle, {
+    bool wholeWord = false,
+    bool caseInsensitive = false,
+  }) {
+    return _buildStringMatchPattern(
+      needle,
+      wholeWord: wholeWord,
+      caseInsensitive: caseInsensitive,
+    ).hasMatch(this);
   }
 
   String removeUrls() {
@@ -39,5 +48,21 @@ extension CleanMessage on String {
       caseSensitive: false,
     );
     return replaceAll(urlPattern, '');
+  }
+
+  RegExp _buildStringMatchPattern(
+    String word, {
+    required bool wholeWord,
+    required bool caseInsensitive,
+    bool isUsername = false,
+  }) {
+    if (wholeWord) {
+      final leadingPattern = isUsername ? r'(^|\s|@)' : r'(^|\s)';
+      final patternString =
+          leadingPattern + RegExp.escape(word) + r'(\s|[.,!?:;]|$)';
+      return RegExp(patternString, caseSensitive: !caseInsensitive);
+    } else {
+      return RegExp(RegExp.escape(word), caseSensitive: !caseInsensitive);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds a Word Filter settings screen where users can define words/phrases that trigger message filtering
- Supports Block Mode (skip messages containing the word) and Allowlist Mode (only read messages containing the word)
- Each rule supports case-sensitive and whole-word-only matching, with badges shown in the list UI
- Adds `containsString` utility to `clean_message_util.dart` and unifies the whole-word boundary pattern into a shared `_buildStringMatchPattern` helper; fixes asymmetric boundary matching by using lookbehind/lookahead (`(?<![a-zA-Z0-9])..(?![a-zA-Z0-9])`), which correctly handles quotes, parentheses, and other surrounding punctuation