### PR TITLE
Decouple display version from build number, update API URL, fixed pancilist

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,11 +28,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Extract version from pubspec.yaml
+      - name: Extract version from app_version.dart
         id: version
         shell: bash
         run: |
-          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | sed 's/+.*//' | tr -d '[:space:]')
+          VERSION=$(grep 'appDisplayVersion' lib/app_version.dart | sed 's/.*"\(.*\)".*/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create and push tag

--- a/lib/app_version.dart
+++ b/lib/app_version.dart
@@ -1,0 +1,2 @@
+const String appDisplayVersion = "0.11";
+const int appBuildNumber = 1;

--- a/lib/services/middlewares/pachify_middleware.dart
+++ b/lib/services/middlewares/pachify_middleware.dart
@@ -1,3 +1,4 @@
+import 'package:streamkit_tts/flavor_config.dart';
 import 'package:streamkit_tts/models/messages/chat_message.dart';
 import 'package:streamkit_tts/models/messages/message.dart';
 import 'package:streamkit_tts/services/middlewares/middleware.dart';
@@ -17,11 +18,14 @@ class PachifyMiddleware implements Middleware {
   @override
   Future<Message?> process(Message message) async {
     if (message is! ChatMessage) return message;
+    final user = FlavorConfig.isYouTube ? message.userId : message.username;
+
     var messageText = _miscTtsUtil.pachify(
       message.suggestedSpeechMessage,
-      userId: message.userId,
+      user: user,
       panciList: _externalConfig.panciList,
     );
+
     messageText = _miscTtsUtil.warafy(messageText);
 
     return message.copyWith(

--- a/lib/services/version_check_service.dart
+++ b/lib/services/version_check_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
-
 import 'package:http/http.dart' as http;
-import 'package:package_info_plus/package_info_plus.dart';
-import 'package:version/version.dart';
+import 'package:streamkit_tts/app_version.dart';
+import 'package:streamkit_tts/flavor_config.dart';
 
 enum VersionState {
   loading,
@@ -17,22 +17,25 @@ enum VersionState {
 class VersionStatus {
   final VersionState state;
   final String latestVersion;
-  final String downloadUrl;
+  final String? downloadUrl;
   final String? announcement;
   final String? announcementUrl;
+  final String? md5;
 
   VersionStatus({
     required this.state,
     this.latestVersion = "0.0.0",
-    required this.downloadUrl,
+    this.downloadUrl,
     this.announcement,
     this.announcementUrl,
+    this.md5,
   });
 }
 
 class VersionCheckService extends ChangeNotifier {
-  final _apiUrl = "https://pastebin.com/raw/2VAGpvdE";
-  final String _defaultDownloadUrl = "https://discord.nnt.gg";
+  final _apiUrl = FlavorConfig.isYouTube
+      ? "https://mentegago.github.io/streamkit-config/app-yt.json"
+      : "https://mentegago.github.io/streamkit-config/app-ttv.json";
 
   late VersionStatus _status;
   String? _currentVersion;
@@ -53,53 +56,72 @@ class VersionCheckService extends ChangeNotifier {
   void _checkLatestVersion() async {
     // I really don't want version checking system to crash the app.
     try {
-      _updateState(VersionStatus(
-        state: VersionState.loading,
-        downloadUrl: _defaultDownloadUrl,
-      ));
+      _updateState(
+        VersionStatus(
+          state: VersionState.loading,
+          downloadUrl: null,
+        ),
+        currentVersion: appDisplayVersion,
+      );
 
       final response = await http.get(
         Uri.parse(_apiUrl),
       );
 
       if (response.statusCode != 200) {
-        _updateState(VersionStatus(
-          state: VersionState.error,
-          downloadUrl: _defaultDownloadUrl,
-        ));
+        _updateState(
+          VersionStatus(
+            state: VersionState.error,
+            downloadUrl: null,
+          ),
+          currentVersion: appDisplayVersion,
+        );
         return;
       }
 
       final Map<String, dynamic> json = jsonDecode(response.body);
-      final String latestVersionString = json["latestVersion"];
-      final String downloadUrl = json["downloadUrl"] ?? _defaultDownloadUrl;
 
-      final packageInfo = await PackageInfo.fromPlatform();
+      final String? platformKey = Platform.isWindows ? "windows" : null;
+      if (platformKey == null || !json.containsKey(platformKey)) {
+        _updateState(
+          VersionStatus(
+            state: VersionState.error,
+            downloadUrl: null,
+          ),
+          currentVersion: appDisplayVersion,
+        );
+        return;
+      }
 
-      final currentVersion = Version.parse(packageInfo.version);
-      final latestVersion = Version.parse(latestVersionString);
+      final platform = json[platformKey] as Map<String, dynamic>;
+      final int latestBuildNumber = platform["latestBuildNumber"] as int;
+      final String latestVersionString = platform["latestVersion"] as String;
+      final String? downloadUrl = platform["downloadUrl"] as String?;
+      final String? md5 = platform["md5"] as String?;
 
-      if (latestVersion > currentVersion) {
+      if (latestBuildNumber > appBuildNumber) {
         _updateState(
           VersionStatus(
             state: VersionState.outdated,
             latestVersion: latestVersionString,
             downloadUrl: downloadUrl,
-            announcement: json["outOfDateAnnouncement"],
-            announcementUrl: json["outOfDateAnnouncementUrl"],
+            announcement: platform["outOfDateAnnouncement"] as String?,
+            announcementUrl: platform["outOfDateAnnouncementUrl"] as String?,
+            md5: md5,
           ),
-          currentVersion: packageInfo.version,
+          currentVersion: appDisplayVersion,
         );
-      } else if (latestVersion == currentVersion) {
+      } else if (latestBuildNumber == appBuildNumber) {
         _updateState(
           VersionStatus(
             state: VersionState.upToDate,
             latestVersion: latestVersionString,
             downloadUrl: downloadUrl,
-            announcement: json["currentAnnouncement"],
-            announcementUrl: json["currentAnnouncementUrl"],
+            announcement: platform["upToDateAnnouncement"] as String?,
+            announcementUrl: platform["upToDateAnnouncementUrl"] as String?,
+            md5: md5,
           ),
-          currentVersion: packageInfo.version,
+          currentVersion: appDisplayVersion,
         );
       } else {
         _updateState(
@@ -107,17 +129,22 @@ class VersionCheckService extends ChangeNotifier {
             state: VersionState.beta,
             latestVersion: latestVersionString,
             downloadUrl: downloadUrl,
-            announcement: json["currentAnnouncement"],
-            announcementUrl: json["currentAnnouncementUrl"],
+            announcement: platform["betaAnnouncement"] as String?,
+            announcementUrl: platform["betaAnnouncementUrl"] as String?,
+            md5: md5,
           ),
-          currentVersion: packageInfo.version,
+          currentVersion: appDisplayVersion,
         );
       }
     } catch (e) {
-      _updateState(VersionStatus(
-        state: VersionState.error,
-        downloadUrl: _defaultDownloadUrl,
-      ));
+      debugPrint("Error checking latest version: $e");
+      _updateState(
+        VersionStatus(
+          state: VersionState.error,
+          downloadUrl: null,
+        ),
+        currentVersion: appDisplayVersion,
+      );
     }
   }
 }

--- a/lib/utils/external_config_util.dart
+++ b/lib/utils/external_config_util.dart
@@ -49,7 +49,7 @@ class ExternalConfig {
   Future<void> loadPanciList() async {
     try {
       final response = await http.get(Uri.parse(
-        "https://pastebin.com/raw/NtEsN3nQ",
+        "https://mentegago.github.io/streamkit-config/panci.txt",
       ));
 
       if (response.statusCode != 200) return;
@@ -66,8 +66,8 @@ class ExternalConfig {
 
   Future<void> loadNameFixList() async {
     try {
-      final response =
-          await http.get(Uri.parse("https://pastebin.com/raw/vrrsngeG"));
+      final response = await http.get(Uri.parse(
+          "https://mentegago.github.io/streamkit-config/name-fix.json"));
       if (response.statusCode != 200) return;
       _nameFixConfig = NameFixConfig.fromJson(json.decode(response.body));
     } catch (_) {
@@ -77,8 +77,8 @@ class ExternalConfig {
 
   Future<void> loadWordFixList() async {
     try {
-      final response =
-          await http.get(Uri.parse("https://pastebin.com/raw/q6yjNmSi"));
+      final response = await http.get(Uri.parse(
+          "https://mentegago.github.io/streamkit-config/word-fix.json"));
       if (response.statusCode != 200) return;
       _wordFixConfig = NameFixConfig.fromJson(json.decode(response.body));
     } catch (_) {

--- a/lib/utils/external_config_util.dart
+++ b/lib/utils/external_config_util.dart
@@ -52,6 +52,7 @@ class ExternalConfig {
         "https://mentegago.github.io/streamkit-config/panci.txt",
       ));
 
+      print("Panci list response: ${response.body}");
       if (response.statusCode != 200) return;
       _panciList.clear();
 
@@ -59,7 +60,8 @@ class ExternalConfig {
         if (element.trim().isEmpty) return;
         _panciList.add(element);
       });
-    } catch (_) {
+    } catch (e) {
+      print(e);
       rethrow;
     }
   }

--- a/lib/utils/misc_tts_util.dart
+++ b/lib/utils/misc_tts_util.dart
@@ -1,7 +1,7 @@
 class MiscTts {
   String pachify(
     String text, {
-    required String userId,
+    required String user,
     required Set<String> panciList,
   }) {
     final defaultUsernameList = [
@@ -19,9 +19,9 @@ class MiscTts {
     final usernameList = panciList.isEmpty ? defaultUsernameList : panciList;
 
     String pachiReplacement = 'パチパチパチ';
-    if (usernameList.contains(userId.toLowerCase()) ||
+    if (usernameList.contains(user.toLowerCase()) ||
         usernameList.contains(
-          userId, // Handle YouTube case where userId is case-sensitive
+          user, // Handle YouTube case where userId is case-sensitive
         )) {
       pachiReplacement = 'panci panci panci';
     }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,7 +9,6 @@ import audio_session
 import audioplayers_darwin
 import bitsdojo_window_macos
 import just_audio
-import package_info_plus
 import path_provider_foundation
 import url_launcher_macos
 
@@ -18,7 +17,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   BitsdojoWindowPlugin.register(with: registry.registrar(forPlugin: "BitsdojoWindowPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
-  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -429,22 +429,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  package_info_plus:
-    dependency: "direct main"
-    description:
-      name: package_info_plus
-      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.1.0"
-  package_info_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: package_info_plus_platform_interface
-      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -762,14 +746,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  version:
-    dependency: "direct main"
-    description:
-      name: version
-      sha256: "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.10.1+1
+version: 0.11.0+1
 
 environment:
   sdk: '^3.2.0'
@@ -50,8 +50,6 @@ dependencies:
   path_provider: ^2.0.9
   uuid: ^4.4.0
   tuple: ^2.0.0
-  package_info_plus: ^8.0.0
-  version: ^3.0.2
   url_launcher: ^6.1.0
   collection: ^1.16.0
   audioplayers: ^6.0.0

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -63,13 +63,13 @@ IDI_APP_ICON            ICON                    "resources\\app_icon.ico"
 #ifdef FLUTTER_BUILD_NUMBER
 #define VERSION_AS_NUMBER FLUTTER_BUILD_NUMBER
 #else
-#define VERSION_AS_NUMBER 0,10,1
+#define VERSION_AS_NUMBER 0,11,0
 #endif
 
 #ifdef FLUTTER_BUILD_NAME
 #define VERSION_AS_STRING #FLUTTER_BUILD_NAME
 #else
-#define VERSION_AS_STRING "0.10.1"
+#define VERSION_AS_STRING "0.11.0"
 #endif
 
 VS_VERSION_INFO VERSIONINFO


### PR DESCRIPTION
## Summary

- Replaces semver-based version comparison with an integer `appBuildNumber` constant, allowing display versions like `0.11-beta` without breaking comparison logic
- Adds `lib/app_version.dart` as the single source of truth for both the display version (`appDisplayVersion`) and build number (`appBuildNumber`)
- Updates version check API to a new platform-keyed JSON structure hosted on GitHub Pages (separate URLs per flavor), with dedicated announcement fields for `outOfDate`, `upToDate`, and `beta` states
- `downloadUrl` is now optional — no button is shown when absent
- Removes `package_info_plus` and `version` pub dependencies